### PR TITLE
Double click for quick compare and ctrl+click for new tab

### DIFF
--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -1,6 +1,6 @@
 'use strict';
 unitDb.controllers = {
-    homeCtrl: ['$scope', 'data', function($scope, data) {
+    homeCtrl: ['$scope', '$window', '$location', 'data', function($scope, $window, $location, data) {
         $scope.factions = [];
         $scope.kinds = [];
         $scope.tech = [];
@@ -58,6 +58,37 @@ unitDb.controllers = {
             return ($scope.factions.length === 0 || isInArray($scope.factions, e.faction)) &&
                        ($scope.kinds.length === 0 || isInArray($scope.kinds, e.classification)) &&
                        ($scope.tech.length === 0 || isInArray($scope.tech, e.tech));
+        };
+        
+        var lastClickTime = 0;
+        var lastClickUnit = null;
+        var maxDoubleClickDelay = 500; //in miliseconds
+        
+        $scope.unitClick = function(unit, event) {
+            //What happens when the user click on a unit thumbnail in the home 
+            //view (the click actually happens in the thumb view)
+            
+            if (event.ctrlKey) {//The control key is pressed: we open a new page 
+                //with only the unit
+                $window.open('#/' + unit.id, '_blank');
+                
+            } else {
+                var newTime = (new Date()).getTime();
+                
+                if ((lastClickUnit === unit) && //it a double click: we go to 
+                        (newTime - lastClickTime) < maxDoubleClickDelay) { //compare view
+                    if (!unit.selected)
+                        $scope.compare(unit);
+                    
+                    var newURL = '/' + $scope.contenders.join(',');
+                    $scope.$apply($location.path( newURL ));
+                    
+                } else {
+                    lastClickUnit = unit;
+                    lastClickTime = newTime;
+                    $scope.compare(unit);
+                }
+            }
         };
     }],
 

--- a/app/js/directives.js
+++ b/app/js/directives.js
@@ -5,10 +5,6 @@ unitDb.directives = {
             restrict: 'E',
             replace: true,
             templateUrl: 'views/thumb.html',
-            scope: {
-                item: '=content',
-                click: '&'
-            }
         };
     }],
 

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -2,14 +2,14 @@
 <section ng-repeat="f in ['UEF', 'Cybran', 'Aeon', 'Seraphim']" class="faction">
     <h1 class="{{ f|lowercase }}">{{ f }}</h1>
     <div class="kind" ng-repeat="c in ['Build', 'Base', 'Land', 'Air', 'Naval']">
-        <thumb ng-repeat="u in index|where:{faction: f, classification: c}|filter:strain|filter:expr" content="u" click="compare(u)"></ng-thumb>
+        <thumb ng-repeat="item in index|where:{faction: f, classification: c}|filter:strain|filter:expr"></ng-thumb>
     </div>
 </section>
 <aside class="filters">
     <header>
         <span class="count" title="{{ contenders.length }} selected">{{ contenders.length }}</span>
         <a href="#/" title="clear selection" class="clear" ng-click="clear()">x</a>
-        <a href="#/{{ contenders.join(',') }}" title="compare" ng-class="{ glow: contenders.length, compare: true }">compare</a>
+        <a ng-href="#/{{ contenders.join(',') }}" title="compare" ng-class="{ glow: contenders.length, compare: true }">compare</a>
     </header>
     <input type="text" placeholder="filter" autofocus ng-model="expr" />
     <p>
@@ -22,4 +22,4 @@
         <a ng-repeat="t in ['T1', 'T2', 'T3', 'EXP']" title="{{ t }}" ng-click="toggleTech(t)" ng-class="{active: techSelected(t)}" class="icon-{{ t }}"></a>
     </p>
 </aside>
-<footer><span>last update: 2015-10-25</span> | <span>unit count: {{ index.length }}</span> | <a href="https://github.com/spooky/unitdb/issues">issues</a> | <a href="https://github.com/spooky/unitdb">source</a></footer>
+<footer><span>last update: 2016-01-19</span> | <span>unit count: {{ index.length }}</span> | <a href="https://github.com/spooky/unitdb/issues">issues</a> | <a href="https://github.com/spooky/unitdb">source</a></footer>

--- a/app/views/thumb.html
+++ b/app/views/thumb.html
@@ -1,3 +1,7 @@
-<a class="thumb {{ item.faction|lowercase }} icon-{{ item.id }}" ng-class="{selected: item.selected}" title="{{ item.fullName }}" ng-click="click()">
+<a class="thumb {{ item.faction|lowercase }} icon-{{ item.id }}"
+    ng-class="{selected: item.selected}"
+    title="{{ item.fullName }}"
+    ng-click="unitClick(item,$event)"
+>
     <span class="strategic icon-{{ item.faction  }}_{{ item.strategicIcon}}" ></span>
 </a>


### PR DESCRIPTION
This tries to answer issue #11 "ctrl + click on thumb navigates to unit details instead of adding to compare list" where @spooky commented "or maybe ctrl+click will trigger comparison ??" 

The implemented effect is as follow:
- ctrl + click opens a new tab with only the unit ctrl clicked on
- double click (within a delay of 0.5 second) opens the compare view with the current units
- simple click is unchanged

The modifications of the code are as follow:
- a new function, unitClick, in the home controller manages the clicks and branches between single, double and ctrl-ed clicks. The detection of double click uses two variables to record the time and unit at the last click, the detection of ctrl uses the javascript event generated when the click occurs.
- the directive 'thumb' was simplified. Instead of creating a new scope for each thumb (with, as field 'click', the closure of the 'compare' function from the scope of the parent) it directly uses the scope of homeCtrl. The alternative would be to have 'click' as a function of the event but it's more expensive to compute new scopes for the client and the risk of scope pollution is zero here.

 