### PR TITLE
Allow missing local.conf.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,13 +16,22 @@ module.exports = function (grunt) {
   require('time-grunt')(grunt);
 
   // Define the configuration for all the tasks
+  var dist_location = 'dist';
+  
+  try {
+    dist_location = require('./local.conf.json').distPath;  
+  } catch(e) {
+    grunt.log.writeln('Cannot use configuration from local.conf.json, using ' +
+    'default configuration instead.');
+  }
+  
   grunt.initConfig({
 
     // Project settings
     yeoman: {
       // configurable paths
       app: require('./bower.json').appPath || 'app',
-      dist: require('./local.conf.json').distPath || 'dist'
+      dist: dist_location//require('./local.conf.json').distPath || 'dist'
     },
 
     // Watches files for changes and runs tasks based on the changed files


### PR DESCRIPTION
Prevent a blocking error from the missing configuration file *local.conf.json* (cf #35). Instead write a line of log.