### PR TITLE
Making filters position automatic to avoids body top margin in other views 

### DIFF
--- a/app/css/main.css
+++ b/app/css/main.css
@@ -179,7 +179,8 @@ footer {
     padding: .67em 0;
 }
 .filters {
-    float: left;
+    float: right;/*To have almost the same behaviour as before:
+    aside bar on the right when the screen is big enough*/
     max-width: 153px;
     margin-left: 3px;
     overflow: hidden;
@@ -346,13 +347,12 @@ h1.seraphim { background-image: url(../img/SC_Seraphim.jpg) }
 /* filter horizontal */
 @media only screen and (max-width: 1373px) {
     body {
-        margin-top: 51px;
         background-image: none;
         background-size: auto;
     }
     .filters {
-        position: absolute;
-        top: -51px;
+        display: inline;
+        top: 0px;
         left: 0;
         width: 100%;
         max-width: none;
@@ -411,12 +411,6 @@ h1.seraphim { background-image: url(../img/SC_Seraphim.jpg) }
 
 /* 2 line horizontal filter */
 @media only screen and (max-width: 1041px) {
-    body {
-        margin-top: 99px;
-    }
-    .filters {
-        top: -99px;
-    }
     .filters input {
         clear: left;
     }
@@ -424,11 +418,7 @@ h1.seraphim { background-image: url(../img/SC_Seraphim.jpg) }
 
 /* 3 line horizontal filter */
 @media only screen and (max-width: 796px) {
-    body {
-        margin-top: 146px;
-    }
     .filters {
-        top: -146px;
         text-align: center;
     }
     .filters header, .filters input {
@@ -450,14 +440,8 @@ h1.seraphim { background-image: url(../img/SC_Seraphim.jpg) }
 
 /* 5 line horizontal filter */
 @media only screen and (max-width: 630px) {
-    body {
-        margin-top: 242px;
-    }
     h1 {
         font-size: 1em;
-    }
-    .filters {
-        top: -242px;
     }
     .filters p {
         float: none;

--- a/app/views/home.html
+++ b/app/views/home.html
@@ -1,10 +1,4 @@
 <!--header><h1>Forged Alliance Forever Unit Database</h1></header-->
-<section ng-repeat="f in ['UEF', 'Cybran', 'Aeon', 'Seraphim']" class="faction">
-    <h1 class="{{ f|lowercase }}">{{ f }}</h1>
-    <div class="kind" ng-repeat="c in ['Build', 'Base', 'Land', 'Air', 'Naval']">
-        <thumb ng-repeat="item in index|where:{faction: f, classification: c}|filter:strain|filter:expr"></ng-thumb>
-    </div>
-</section>
 <aside class="filters">
     <header>
         <span class="count" title="{{ contenders.length }} selected">{{ contenders.length }}</span>
@@ -22,4 +16,11 @@
         <a ng-repeat="t in ['T1', 'T2', 'T3', 'EXP']" title="{{ t }}" ng-click="toggleTech(t)" ng-class="{active: techSelected(t)}" class="icon-{{ t }}"></a>
     </p>
 </aside>
+<section ng-repeat="f in ['UEF', 'Cybran', 'Aeon', 'Seraphim']" class="faction">
+    <h1 class="{{ f|lowercase }}">{{ f }}</h1>
+    <div class="kind" ng-repeat="c in ['Build', 'Base', 'Land', 'Air', 'Naval']">
+        <thumb ng-repeat="item in index|where:{faction: f, classification: c}|filter:strain|filter:expr"></ng-thumb>
+    </div>
+</section>
+
 <footer><span>last update: 2016-01-19</span> | <span>unit count: {{ index.length }}</span> | <a href="https://github.com/spooky/unitdb/issues">issues</a> | <a href="https://github.com/spooky/unitdb">source</a></footer>


### PR DESCRIPTION
Currently the position of the filters and the section containing the units' thumbs is set (in app/css/main.css) using a margin-top in body and the same length in negative top absolute position for filters, for instance:

```
@media only screen and (max-width: 1041px) {
    body {
        margin-top: 99px;
    }
    .filters {
        top: -99px;
    }
}
```

This works great for the home view for which it was made for but it breaks the compare view where there is no filters: when the screen width is smaller than 1373px this leave a visible blank at the top of the page.

This PR addresses this by putting the filters before the units section in the view and:
- inline it when the screen is not wide enough (this forces the section to the right position automatically)
- float it to the right when the screen is wide enough. This change slightly the presentation: previously it was floated left, forcing in to touch the section, it now touches the right border of the document.