### PR TITLE
Move T3 Engineering Station to T2 Engineering Station in by-class view (since it can't be build directly)

### DIFF
--- a/app/js/UnitDecorator.js
+++ b/app/js/UnitDecorator.js
@@ -35,6 +35,7 @@ unitDb.UnitDecorator = function(blueprint) {
             'Seraphim': 3,
         },
         gdiClassificationLookup = {
+            'XEB0204': 'T2 Engineering Station',
             'UEL0401': 'Direct Fire Experimental',
             'UAL0401': 'Direct Fire Experimental',
             'XSL0401': 'Direct Fire Experimental',


### PR DESCRIPTION
Change requested by [GDI]svenni_badwoi shown in ![this pic](https://cloud.githubusercontent.com/assets/1616581/24067335/6855a118-0b7b-11e7-804e-9a21f92d169a.png)

I only tried to make the T3->T2 grouping work, because I think adding T1 drone to T2 EngStation would put T1 drone in front / at first column of the group. Didn't feel like adding another layer of abstraction to order this like in the picture ;)

I didn't test the change cause reasons (Sorry!), but have strong faith in it working. Please test and consider this pull request.