### PR TITLE
Fix Typo in DPS calculations

### DIFF
--- a/app/js/dps.js
+++ b/app/js/dps.js
@@ -126,7 +126,7 @@ unitDb.NotNukeDpsCalculator = angular.extend({}, unitDb.DpsCalculator, {
 
         var trueDamage = w.Damage*(w.DoTPulses || 1) + (w.InitialDamage || 0);
         // beam weapons are a thing and do their own thing. yeah good luck working out that.
-        trueDamage = Math.max((Math.floor((w.BeamLifetime || 0) / ((w.BeamCollisionDelay || 0)+0.1))-1)*w.Damage, trueDamage);
+        trueDamage = Math.max((Math.floor((w.BeamLifetime || 0) / ((w.BeamCollisionDelay || 0)+0.1))+1)*w.Damage, trueDamage);
         var salvoDamage = trueSalvoSize * trueDamage * (isSpecial ? w.ProjectilesPerOnFire || 1 : 1);
         var trueDPS = (salvoDamage / trueReload);
 


### PR DESCRIPTION
this causes beams to have 1 less collision count and not 1 more = the beam collides after each wait period, AND at the start which results in one more damage pulse per beam "salvo"

there was a typo where it is -1 and not +1, which didnt make sense because it could have given a negative number of pulses :/
the code for 0 collision delay though made it give the regular dps in these cases though so it wasnt obvious.